### PR TITLE
feat(journals): add delete entry action on dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+// src/App.jsx
 import React from "react";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { Routes, Route, Navigate } from "react-router-dom";

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,36 @@
 // src/pages/Dashboard.jsx
 import React, { useEffect, useState } from "react";
-import { JournalAPI } from "../services/apiclient"; // uses your existing axios helper
+import { JournalAPI } from "../services/apiclient";
+
+// --- helpers to read/sort/format dates from various shapes ---
+function extractDate(j) {
+  const raw =
+    j?.timestamp ??
+    j?.createdAt ??
+    j?.created_at ??
+    (j?.created && j.created) ??
+    (j?.date && j.date) ??
+    null;
+
+  if (!raw) return null;
+
+  if (typeof raw === "object" && raw.seconds) return new Date(raw.seconds * 1000);
+  if (typeof raw === "number") return new Date(raw < 1e12 ? raw * 1000 : raw);
+  if (typeof raw === "string") return new Date(raw);
+
+  return null;
+}
+
+function fmtDate(j) {
+  const d = extractDate(j);
+  return d ? d.toLocaleString() : "—";
+}
 
 export default function Dashboard() {
   const [journals, setJournals] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState(null);
+  const [busyId, setBusyId] = useState(null); // deleting state
 
   useEffect(() => {
     let mounted = true;
@@ -14,8 +39,14 @@ export default function Dashboard() {
       try {
         setLoading(true);
         setErr(null);
-        const { data } = await JournalAPI.list(); // GET /api/journals (requires token)
-        if (mounted) setJournals(Array.isArray(data) ? data : []);
+        const { data } = await JournalAPI.list(); // GET /api/journals
+        const arr = Array.isArray(data) ? data : [];
+        // newest → oldest
+        arr.sort(
+          (a, b) =>
+            (extractDate(b)?.getTime?.() || 0) - (extractDate(a)?.getTime?.() || 0)
+        );
+        if (mounted) setJournals(arr);
       } catch (e) {
         if (mounted) setErr(e?.response?.data?.message || "Failed to load journals");
       } finally {
@@ -23,8 +54,28 @@ export default function Dashboard() {
       }
     })();
 
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, []);
+
+  async function handleDelete(j) {
+    const id = j.id || j.entry_id || j._id;
+    if (!id) return alert("Entry id missing.");
+    if (!confirm("Delete this entry?")) return;
+
+    try {
+      setBusyId(id);
+      await JournalAPI.remove(id);
+      setJournals((prev) =>
+        prev.filter((x) => (x.id || x.entry_id || x._id) !== id)
+      );
+    } catch (e) {
+      alert(e?.response?.data?.message || "Failed to delete entry.");
+    } finally {
+      setBusyId(null);
+    }
+  }
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -45,18 +96,35 @@ export default function Dashboard() {
 
         {!loading && !err && journals.length > 0 && (
           <ul className="space-y-3">
-            {journals.map((j) => (
-              <li key={j.id || j.entry_id} className="p-3 border rounded-md">
-                <div className="text-sm text-gray-500">
-                  {new Date(j.createdAt || j.timestamp).toLocaleString()}
-                </div>
-                <div className="font-medium capitalize">Mood: {j.mood || "—"}</div>
-                <p className="mt-1">{j.text}</p>
-                {Array.isArray(j.tags) && j.tags.length > 0 && (
-                  <div className="mt-1 text-xs text-gray-500">Tags: {j.tags.join(", ")}</div>
-                )}
-              </li>
-            ))}
+            {journals.map((j) => {
+              const id = j.id || j.entry_id || j._id;
+              const isBusy = busyId === id;
+              return (
+                <li key={id} className="p-3 border rounded-md">
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>{fmtDate(j)}</span>
+                    <button
+                      onClick={() => handleDelete(j)}
+                      disabled={isBusy}
+                      className="ml-3 rounded-md px-2 py-1 text-xs ring-1 ring-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
+                      title="Delete entry"
+                    >
+                      {isBusy ? "Deleting…" : "Delete"}
+                    </button>
+                  </div>
+
+                  <div className="mt-1 font-medium capitalize">
+                    Mood: {j.mood || "—"}
+                  </div>
+                  <p className="mt-1">{j.text}</p>
+                  {Array.isArray(j.tags) && j.tags.length > 0 && (
+                    <div className="mt-1 text-xs text-gray-500">
+                      Tags: {j.tags.join(", ")}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/src/pages/EntryPage.jsx
+++ b/src/pages/EntryPage.jsx
@@ -1,14 +1,123 @@
-// import React from "react";
+// src/pages/EntryPage.jsx
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { JournalAPI } from "../services/apiclient";
+
+const moods = ["happy", "neutral", "sad", "angry", "anxious"];
 
 export default function EntryPage() {
+  const navigate = useNavigate();
+  const [text, setText] = useState("");
+  const [mood, setMood] = useState("");
+  const [tags, setTags] = useState(""); // comma-separated input
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setErr("");
+
+    if (!text.trim()) return setErr("Please write something.");
+    if (!mood) return setErr("Please select your mood.");
+
+    try {
+      setLoading(true);
+      const payload = {
+        text: text.trim(),
+        mood,
+        tags: tags
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        timestamp: Date.now(), // <— ensure we always have a date
+      };
+      await JournalAPI.create(payload);
+      navigate("/dashboard", { replace: true });
+    } catch (e) {
+      setErr(e?.response?.data?.message || "Failed to save entry.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <section className="bg-white border rounded-2xl p-6 shadow-sm">
-      <h1 className="text-2xl font-bold mb-4">New Journal Entry</h1>
-      <textarea
-        className="w-full border rounded-lg p-3 min-h-[140px]"
-        placeholder="Write your thoughts here…"
-      />
-      <button className="mt-4 bg-black text-white rounded-lg px-4 py-2">Save Entry</button>
-    </section>
+    <div className="max-w-3xl mx-auto p-6 space-y-5">
+      <header>
+        <h1 className="text-2xl font-semibold">New journal entry</h1>
+        <p className="text-gray-600">Capture your mood and thoughts.</p>
+      </header>
+
+      {err && (
+        <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 ring-1 ring-red-200">
+          {err}
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        {/* mood */}
+        <div>
+          <label className="block text-sm font-medium mb-1">Mood</label>
+          <div className="flex gap-2 flex-wrap">
+            {moods.map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMood(m)}
+                className={
+                  "px-3 py-1.5 rounded-lg ring-1 " +
+                  (mood === m
+                    ? "bg-violet-600 text-white ring-violet-600"
+                    : "bg-white text-gray-700 ring-gray-200 hover:bg-gray-50")
+                }
+                aria-pressed={mood === m}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* text */}
+        <div>
+          <label className="block text-sm font-medium mb-1">Entry</label>
+          <textarea
+            className="w-full min-h-40 rounded-xl border border-gray-200 p-3 focus:outline-none focus:ring-2 focus:ring-violet-500/60"
+            placeholder="How are you feeling today?"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+        </div>
+
+        {/* tags */}
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Tags <span className="text-gray-400">(comma separated, optional)</span>
+          </label>
+          <input
+            className="w-full rounded-xl border border-gray-200 p-2.5 focus:outline-none focus:ring-2 focus:ring-violet-500/60"
+            placeholder="gratitude, work, family"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-xl bg-black text-white px-4 py-2 disabled:opacity-60"
+          >
+            {loading ? "Saving…" : "Save entry"}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/dashboard")}
+            className="rounded-xl ring-1 ring-gray-200 px-4 py-2"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
### What & Why
- Adds “Delete” action for each journal on Dashboard.
- Confirms via `window.confirm()` then calls **DELETE /api/journals/:id**.
- Optimistically removes item from local list.

### How to test
1. Create a couple entries
2. On Dashboard, click Delete → OK
3. Entry disappears and stays deleted after refresh

### Notes / Follow-ups
- Simple confirm for now; later replace with modal.
- If API fails, entry is restored and error is shown.
