### PR TITLE
feat(journals): enable edit entry (PUT with safe fallback)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,8 @@ export default function App() {
               </ProtectedRoute>
             }
           />
+
+          {/* Create new */}
           <Route
             path="/entry"
             element={
@@ -41,6 +43,17 @@ export default function App() {
               </ProtectedRoute>
             }
           />
+
+          {/* === BEGIN: Edit route added === */}
+          <Route
+            path="/entry/:id"
+            element={
+              <ProtectedRoute>
+                <EntryPage />
+              </ProtectedRoute>
+            }
+          />
+          {/* === END: Edit route added === */}
 
           {/* Fallback */}
           <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,156 @@
+// // src/pages/Dashboard.jsx
+// import React, { useEffect, useState } from "react";
+// import { JournalAPI } from "../services/apiclient";
+// import { Link } from "react-router-dom"; // === Added for Edit link ===
+
+// // --- helpers to read/sort/format dates from various shapes ---
+// function extractDate(j) {
+//   const raw =
+//     j?.timestamp ??
+//     j?.createdAt ??
+//     j?.created_at ??
+//     (j?.created && j.created) ??
+//     (j?.date && j.date) ??
+//     null;
+
+//   if (!raw) return null;
+
+//   if (typeof raw === "object" && raw.seconds) return new Date(raw.seconds * 1000);
+//   if (typeof raw === "number") return new Date(raw < 1e12 ? raw * 1000 : raw);
+//   if (typeof raw === "string") return new Date(raw);
+
+//   return null;
+// }
+
+// function fmtDate(j) {
+//   const d = extractDate(j);
+//   return d ? d.toLocaleString() : "—";
+// }
+
+// export default function Dashboard() {
+//   const [journals, setJournals] = useState([]);
+//   const [loading, setLoading] = useState(true);
+//   const [err, setErr] = useState(null);
+//   const [busyId, setBusyId] = useState(null); // deleting state
+
+//   useEffect(() => {
+//     let mounted = true;
+
+//     (async () => {
+//       try {
+//         setLoading(true);
+//         setErr(null);
+//         const { data } = await JournalAPI.list(); // GET /api/journals
+//         const arr = Array.isArray(data) ? data : [];
+//         // newest → oldest
+//         arr.sort(
+//           (a, b) =>
+//             (extractDate(b)?.getTime?.() || 0) - (extractDate(a)?.getTime?.() || 0)
+//         );
+//         if (mounted) setJournals(arr);
+//       } catch (e) {
+//         if (mounted) setErr(e?.response?.data?.message || "Failed to load journals");
+//       } finally {
+//         if (mounted) setLoading(false);
+//       }
+//     })();
+
+//     return () => {
+//       mounted = false;
+//     };
+//   }, []);
+
+//   async function handleDelete(j) {
+//     const id = j.id || j.entry_id || j._id;
+//     if (!id) return alert("Entry id missing.");
+//     if (!confirm("Delete this entry?")) return;
+
+//     try {
+//       setBusyId(id);
+//       await JournalAPI.remove(id);
+//       setJournals((prev) =>
+//         prev.filter((x) => (x.id || x.entry_id || x._id) !== id)
+//       );
+//     } catch (e) {
+//       alert(e?.response?.data?.message || "Failed to delete entry.");
+//     } finally {
+//       setBusyId(null);
+//     }
+//   }
+
+//   return (
+//     <div className="max-w-3xl mx-auto p-6 space-y-6">
+//       <header>
+//         <h1 className="text-2xl font-semibold">Dashboard</h1>
+//         <p className="text-gray-600">Your recent journal entries</p>
+//       </header>
+
+//       <section className="p-4 rounded-xl border shadow-sm">
+//         <h2 className="text-xl font-medium mb-3">Recent Entries</h2>
+
+//         {loading && <p>Loading…</p>}
+//         {err && <p className="text-red-600">{err}</p>}
+
+//         {!loading && !err && journals.length === 0 && (
+//           <p className="text-gray-600">No entries yet.</p>
+//         )}
+
+//         {!loading && !err && journals.length > 0 && (
+//           <ul className="space-y-3">
+//             {journals.map((j) => {
+//               const id = j.id || j.entry_id || j._id;
+//               const isBusy = busyId === id;
+//               return (
+//                 <li key={id} className="p-3 border rounded-md">
+//                   <div className="flex items-center justify-between text-sm text-gray-500">
+//                     <span>{fmtDate(j)}</span>
+
+//                     {/* === BEGIN: Edit button added (link to /entry/:id) === */}
+//                     <div className="flex items-center gap-2">
+//                       <Link
+//                         to={`/entry/${id}`}
+//                         className="rounded-md px-2 py-1 text-xs ring-1 ring-gray-300 hover:bg-gray-50"
+//                         title="Edit entry"
+//                       >
+//                         Edit
+//                       </Link>
+//                       {/* existing Delete button */}
+//                       <button
+//                         onClick={() => handleDelete(j)}
+//                         disabled={isBusy}
+//                         className="rounded-md px-2 py-1 text-xs ring-1 ring-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
+//                         title="Delete entry"
+//                       >
+//                         {isBusy ? "Deleting…" : "Delete"}
+//                       </button>
+//                     </div>
+//                     {/* === END: Edit button added === */}
+//                   </div>
+
+//                   <div className="mt-1 font-medium capitalize">
+//                     Mood: {j.mood || "—"}
+//                   </div>
+//                   <p className="mt-1">{j.text}</p>
+//                   {Array.isArray(j.tags) && j.tags.length > 0 && (
+//                     <div className="mt-1 text-xs text-gray-500">
+//                       Tags: {j.tags.join(", ")}
+//                     </div>
+//                   )}
+//                 </li>
+//               );
+//             })}
+//           </ul>
+//         )}
+//       </section>
+//     </div>
+//   );
+// }
+
+
 // src/pages/Dashboard.jsx
 import React, { useEffect, useState } from "react";
 import { JournalAPI } from "../services/apiclient";
+import { Link } from "react-router-dom"; // Added for Edit link
 
 // --- helpers to read/sort/format dates from various shapes ---
 function extractDate(j) {
@@ -103,14 +253,27 @@ export default function Dashboard() {
                 <li key={id} className="p-3 border rounded-md">
                   <div className="flex items-center justify-between text-sm text-gray-500">
                     <span>{fmtDate(j)}</span>
-                    <button
-                      onClick={() => handleDelete(j)}
-                      disabled={isBusy}
-                      className="ml-3 rounded-md px-2 py-1 text-xs ring-1 ring-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
-                      title="Delete entry"
-                    >
-                      {isBusy ? "Deleting…" : "Delete"}
-                    </button>
+
+                    {/* === UPDATED START: Edit button/link added === */}
+                    <div className="flex items-center gap-2">
+                      <Link
+                        to={`/entry/${id}`}
+                        className="rounded-md px-2 py-1 text-xs ring-1 ring-gray-300 hover:bg-gray-50"
+                        title="Edit entry"
+                      >
+                        Edit
+                      </Link>
+                      {/* existing Delete button */}
+                      <button
+                        onClick={() => handleDelete(j)}
+                        disabled={isBusy}
+                        className="rounded-md px-2 py-1 text-xs ring-1 ring-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
+                        title="Delete entry"
+                      >
+                        {isBusy ? "Deleting…" : "Delete"}
+                      </button>
+                    </div>
+                    {/* === UPDATED END === */}
                   </div>
 
                   <div className="mt-1 font-medium capitalize">

--- a/src/pages/EntryPage.jsx
+++ b/src/pages/EntryPage.jsx
@@ -1,18 +1,234 @@
+// // src/pages/EntryPage.jsx
+// import React, { useEffect, useMemo, useState } from "react";
+// import { useNavigate, useParams } from "react-router-dom";
+// import { JournalAPI } from "../services/apiclient";
+
+// const moods = ["happy", "neutral", "sad", "angry", "anxious"];
+
+// export default function EntryPage() {
+//   const navigate = useNavigate();
+//   const { id } = useParams();
+//   const isEdit = useMemo(() => Boolean(id), [id]);
+
+//   // form state
+//   const [text, setText] = useState("");
+//   const [mood, setMood] = useState("");
+//   const [tags, setTags] = useState("");
+//   const [loading, setLoading] = useState(false);
+//   const [err, setErr] = useState("");
+
+//   // keep the original entry only to prefill (no longer sent back)
+//   const [original, setOriginal] = useState(null);
+
+//   // Load entry when editing
+//   useEffect(() => {
+//     let mounted = true;
+//     if (!isEdit) return;
+
+//     (async () => {
+//       try {
+//         setLoading(true);
+//         setErr("");
+//         const { data } = await JournalAPI.get(id); // GET /api/journals/:id
+//         if (!mounted || !data) return;
+//         setOriginal(data);
+//         setText(data.text || "");
+//         setMood(data.mood || "");
+//         setTags(Array.isArray(data.tags) ? data.tags.join(", ") : (data.tags || ""));
+//       } catch (e) {
+//         if (mounted) {
+//           console.error("Load entry failed:", e?.response?.data || e);
+//           setErr(e?.response?.data?.message || "Failed to load entry.");
+//         }
+//       } finally {
+//         if (mounted) setLoading(false);
+//       }
+//     })();
+
+//     return () => { mounted = false; };
+//   }, [id, isEdit]);
+
+//   const onSubmit = async (e) => {
+//     e.preventDefault();
+//     setErr("");
+
+//     if (!text.trim()) return setErr("Please write something.");
+//     if (!mood) return setErr("Please select your mood.");
+
+//     // Always send tags as an array (even if empty)
+//     const tagsArray = tags
+//       .split(",")
+//       .map((t) => t.trim())
+//       .filter(Boolean);
+
+//     try {
+//       setLoading(true);
+
+//       if (isEdit) {
+//         // UPDATED START: update sends ONLY { text, mood, tags } via JournalAPI.update guard
+//         const updatePayload = { text: text.trim(), mood, tags: tagsArray };
+//         console.log("[PUT] /api/journals/:id payload =", updatePayload);
+//         await JournalAPI.update(id, updatePayload);
+//         // UPDATED END
+//       } else {
+//         // Keep your current create behavior (timestamp is fine for POST)
+//         const createPayload = {
+//           text: text.trim(),
+//           mood,
+//           tags: tagsArray,
+//           timestamp: Date.now(),
+//         };
+//         await JournalAPI.create(createPayload);
+//       }
+
+//       navigate("/dashboard", { replace: true });
+//     } catch (e2) {
+//       console.error("Save entry failed:", e2?.response?.data || e2);
+//       setErr(e2?.response?.data?.message || "Failed to save entry.");
+//     } finally {
+//       setLoading(false);
+//     }
+//   };
+
+//   return (
+//     <div className="max-w-3xl mx-auto p-6 space-y-5">
+//       <header>
+//         <h1 className="text-2xl font-semibold">
+//           {isEdit ? "Edit journal entry" : "New journal entry"}
+//         </h1>
+//         <p className="text-gray-600">
+//           {isEdit ? "Update mood, text, or tags." : "Capture your mood and thoughts."}
+//         </p>
+//       </header>
+
+//       {err && (
+//         <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 ring-1 ring-red-200">
+//           {err}
+//         </div>
+//       )}
+
+//       <form onSubmit={onSubmit} className="space-y-4">
+//         {/* mood */}
+//         <div>
+//           <label className="block text-sm font-medium mb-1">Mood</label>
+//           <div className="flex gap-2 flex-wrap">
+//             {moods.map((m) => (
+//               <button
+//                 key={m}
+//                 type="button"
+//                 onClick={() => setMood(m)}
+//                 className={
+//                   "px-3 py-1.5 rounded-lg ring-1 " +
+//                   (mood === m
+//                     ? "bg-violet-600 text-white ring-violet-600"
+//                     : "bg-white text-gray-700 ring-gray-200 hover:bg-gray-50")
+//                 }
+//                 aria-pressed={mood === m}
+//               >
+//                 {m}
+//               </button>
+//             ))}
+//           </div>
+//         </div>
+
+//         {/* text */}
+//         <div>
+//           <label className="block text-sm font-medium mb-1">Entry</label>
+//           <textarea
+//             className="w-full min-h-40 rounded-xl border border-gray-200 p-3 focus:outline-none focus:ring-2 focus:ring-violet-500/60"
+//             placeholder="How are you feeling today?"
+//             value={text}
+//             onChange={(e) => setText(e.target.value)}
+//           />
+//         </div>
+
+//         {/* tags */}
+//         <div>
+//           <label className="block text-sm font-medium mb-1">
+//             Tags <span className="text-gray-400">(comma separated, optional)</span>
+//           </label>
+//           <input
+//             className="w-full rounded-xl border border-gray-200 p-2.5 focus:outline-none focus:ring-2 focus:ring-violet-500/60"
+//             placeholder="gratitude, work, family"
+//             value={tags}
+//             onChange={(e) => setTags(e.target.value)}
+//           />
+//         </div>
+
+//         <div className="flex gap-3">
+//           <button
+//             type="submit"
+//             disabled={loading}
+//             className="rounded-xl bg-black text-white px-4 py-2 disabled:opacity-60"
+//           >
+//             {loading ? (isEdit ? "Saving…" : "Saving…") : isEdit ? "Save changes" : "Save entry"}
+//           </button>
+//           <button
+//             type="button"
+//             onClick={() => navigate("/dashboard")}
+//             className="rounded-xl ring-1 ring-gray-200 px-4 py-2"
+//           >
+//             Cancel
+//           </button>
+//         </div>
+//       </form>
+//     </div>
+//   );
+// }
+
+
 // src/pages/EntryPage.jsx
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { JournalAPI } from "../services/apiclient";
 
+// Fixed set of moods for the chip selector
 const moods = ["happy", "neutral", "sad", "angry", "anxious"];
 
 export default function EntryPage() {
   const navigate = useNavigate();
+  const { id } = useParams();
+  const isEdit = useMemo(() => Boolean(id), [id]);
+
+  // --- form state ---
   const [text, setText] = useState("");
   const [mood, setMood] = useState("");
-  const [tags, setTags] = useState(""); // comma-separated input
+  const [tags, setTags] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState("");
 
+  // Keep the original entry only to prefill (not sent back)
+  const [original, setOriginal] = useState(null);
+
+  // Prefill the form when editing
+  useEffect(() => {
+    let mounted = true;
+    if (!isEdit) return;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setErr("");
+        const { data } = await JournalAPI.get(id); // GET /api/journals/:id
+        if (!mounted || !data) return;
+        setOriginal(data);
+        setText(data.text || "");
+        setMood(data.mood || "");
+        setTags(Array.isArray(data.tags) ? data.tags.join(", ") : (data.tags || ""));
+      } catch (e) {
+        if (mounted) {
+          console.error("Load entry failed:", e?.response?.data || e);
+          setErr(e?.response?.data?.message || "Failed to load entry.");
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => { mounted = false; };
+  }, [id, isEdit]);
+
+  // Save handler for both Create + Edit
   const onSubmit = async (e) => {
     e.preventDefault();
     setErr("");
@@ -20,21 +236,55 @@ export default function EntryPage() {
     if (!text.trim()) return setErr("Please write something.");
     if (!mood) return setErr("Please select your mood.");
 
+    // Always send tags as an array (even if empty)
+    const tagsArray = tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    // Payloads (kept small and explicit)
+    const editPayload = { text: text.trim(), mood, tags: tagsArray };
+
+    // We keep timestamp on create to preserve your current behavior
+    const createPayload = {
+      text: text.trim(),
+      mood,
+      tags: tagsArray,
+      timestamp: Date.now(),
+    };
+
+    setLoading(true);
     try {
-      setLoading(true);
-      const payload = {
-        text: text.trim(),
-        mood,
-        tags: tags
-          .split(",")
-          .map((t) => t.trim())
-          .filter(Boolean),
-        timestamp: Date.now(), // <— ensure we always have a date
-      };
-      await JournalAPI.create(payload);
+      if (isEdit) {
+        // === UPDATED START: normal PUT + graceful fallback if server still 405/500 ===
+        try {
+          // Official edit path (mentor API)
+          await JournalAPI.update(id, editPayload); // PUT /api/journals/:id
+        } catch (putErr) {
+          const status = putErr?.response?.status;
+          const shouldFallback = status === 405 || status === 500;
+          if (!shouldFallback) throw putErr; // other errors → bubble
+
+          // Fallback path: create a new entry, then delete the old one
+          try {
+            const { data: created } = await JournalAPI.create(createPayload); // POST works
+            await JournalAPI.remove(id);                                     // delete old
+            // (Optional: you could store a flag to show "edited via fallback" toast)
+          } catch (fallbackErr) {
+            console.error("Fallback edit failed:", fallbackErr?.response?.data || fallbackErr);
+            throw fallbackErr;
+          }
+        }
+        // === UPDATED END ===
+      } else {
+        // Create new entry
+        await JournalAPI.create(createPayload); // POST /api/journals
+      }
+
       navigate("/dashboard", { replace: true });
-    } catch (e) {
-      setErr(e?.response?.data?.message || "Failed to save entry.");
+    } catch (e2) {
+      console.error("Save entry failed:", e2?.response?.data || e2);
+      setErr(e2?.response?.data?.message || "Failed to save entry.");
     } finally {
       setLoading(false);
     }
@@ -43,8 +293,12 @@ export default function EntryPage() {
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-5">
       <header>
-        <h1 className="text-2xl font-semibold">New journal entry</h1>
-        <p className="text-gray-600">Capture your mood and thoughts.</p>
+        <h1 className="text-2xl font-semibold">
+          {isEdit ? "Edit journal entry" : "New journal entry"}
+        </h1>
+        <p className="text-gray-600">
+          {isEdit ? "Update mood, text, or tags." : "Capture your mood and thoughts."}
+        </p>
       </header>
 
       {err && (
@@ -107,7 +361,7 @@ export default function EntryPage() {
             disabled={loading}
             className="rounded-xl bg-black text-white px-4 py-2 disabled:opacity-60"
           >
-            {loading ? "Saving…" : "Save entry"}
+            {loading ? (isEdit ? "Saving…" : "Saving…") : isEdit ? "Save changes" : "Save entry"}
           </button>
           <button
             type="button"

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -15,6 +15,10 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("zen_token");
   if (token) config.headers.Authorization = `Bearer ${token}`;
+  // Keep content-type explicit for JSON writes
+  if (["post", "put", "patch"].includes((config.method || "").toLowerCase())) {
+    config.headers["Content-Type"] = "application/json";
+  }
   return config;
 });
 
@@ -29,7 +33,18 @@ export const JournalAPI = {
   list: () => api.get("/api/journals"),
   create: (payload) => api.post("/api/journals", payload),
   get: (id) => api.get(`/api/journals/${id}`),
-  update: (id, payload) => api.put(`/api/journals/${id}`, payload),
+
+  // UPDATED START: force the PUT body to be exactly { text, mood, tags }
+  update: (id, payload) => {
+    const clean = {
+      text: String(payload?.text ?? "").trim(),
+      mood: String(payload?.mood ?? "").trim(),
+      tags: Array.isArray(payload?.tags) ? payload.tags : [],
+    };
+    return api.put(`/api/journals/${id}`, clean);
+  },
+  // UPDATED END
+
   remove: (id) => api.delete(`/api/journals/${id}`),
 };
 


### PR DESCRIPTION
### What & Why
- Add Edit flow for journals.
- Dashboard cards now have an **Edit** link to `/entry/:id`.
- `EntryPage` handles both Create + Edit.
- Primary path: **PUT /api/journals/:id** with payload `{ text, mood, tags }`.
- Safe fallback: on PUT 405/500, POST a new entry then DELETE the old one to keep UX unblocked.

### How to test
1. Login
2. Create a new entry → appears on Dashboard.
3. Click **Edit** on a card → modify text/mood/tags → **Save changes**.
   - Expect redirect to Dashboard with updated content (PUT success or fallback path).
4. Delete still works from Dashboard.

### Implementation notes
- `Dashboard.jsx`: Edit `<Link to="/entry/:id" />` + keeps Delete.
- `EntryPage.jsx`: loads entry on edit; trims inputs; always sends `tags` as array; PUT-only fields.
- `apiClient.js`: helpers for mentor API; PUT expects `{ text, mood, tags }`.
- `App.jsx`: ensure `/entry/:id` route exists.

### Follow-ups
- Remove fallback once backend PUT is stable.
- Optional: toast when fallback path triggers.
